### PR TITLE
Only titles in overview, click to view.

### DIFF
--- a/viewer/containers/reader.js
+++ b/viewer/containers/reader.js
@@ -11,6 +11,7 @@ function Reader () {
   Nanofetcher.call(this)
   this.gist = null
   this.identity = null
+  this.post = null
 }
 Reader.prototype = Object.create(Nanofetcher.prototype)
 Reader.prototype.constructor = Reader
@@ -30,10 +31,30 @@ Reader.prototype.placeholder = function () {
 }
 
 Reader.prototype.hydrate = function (readrc) {
-  return html`<div>
-    <h1>${readrc.posts[0].title}</h1>
-    <div>${readrc.posts[0].content}</div>
-  </div>`
+  var click = (idx) => () => {
+    this.post = idx + 1
+    this.emit('render')
+  }
+
+  var back = () => {
+    this.post = null
+    this.emit('render')
+  }
+
+  if (!this.post) {
+    var posts = readrc.posts.map((post, idx) => {
+      return html`<li><h2 class="pointer" onclick=${click(idx)}>${post.title}</h2></li>`
+    })
+    return html`<div><ul>${posts}</ul></div>`
+  }
+  else {
+    var post = readrc.posts[this.post - 1]
+    return html`<div class="pa2">
+        <span class="pointer white bg-black mv1 pa2 dim dib" onclick=${back}>Back</span>
+        <h1>${post.title}</h1>
+        <p class="serif lh-copy mw7">${post.content}</p>
+      </div>`
+  }
 }
 
 Reader.prototype.fetch = function (cb) {
@@ -49,6 +70,6 @@ Reader.prototype.fetch = function (cb) {
   }
 }
 
-Reader.prototype.update = function (gist) {
-  return this.identity == Reader.identity(gist)
+Reader.prototype.update = function (gist, token, post) {
+  return !(this.identity === Reader.identity(gist) && this.post === post)
 }

--- a/viewer/views/read.js
+++ b/viewer/views/read.js
@@ -10,10 +10,13 @@ var route = null;
 module.exports = function read (state, emit) {
   var query = qs.parse(window.location.search);
   var gist = query.gist
+  reader.emit = emit
 
   return html`
     <body class="sans-serif black-70">
-      ${reader.render(gist, state.token)}
+      <div class="mw8 center">
+        ${reader.render(gist, state.token)}
+      </div>
       ${(!gist) ? html`<div class="fixed bottom-0 right-0 pb2 pr2"><a href="#" onclick=${onclick} class="f6 link dim br2 ph2 pv1 dib white bg-light-red">⬆</a></div>` : ''}
     </body>
   `


### PR DESCRIPTION
Was playing around with this today. To understand things better, started working a bit in the viewer. This PR makes it list all titles on /read, and makes the titles clickable, leading to a full view. Dunno what's the plan with this, if not needed just close the PR. 
![output2](https://user-images.githubusercontent.com/43627/40366835-5f571442-5dd8-11e8-8425-e7bb9a20fd9b.gif)
